### PR TITLE
Add Medent to the medical source platform filter

### DIFF
--- a/src/app/pages/medical-sources-editor/medical-sources-editor.component.ts
+++ b/src/app/pages/medical-sources-editor/medical-sources-editor.component.ts
@@ -42,6 +42,7 @@ export class MedicalSourcesEditorComponent implements OnInit {
     {key: 'Humana', value: 'humana'},
     {key: 'Kaiser', value: 'kaiser'},
     {key: 'Maximeyes', value: 'maximeyes'},
+    {key: 'Medent', value: 'medent'},
     {key: 'Medhost', value: 'medhost'},
     {key: 'Medicare', value: 'medicare'},
     {key: 'Modmed EMA', value: 'modmedema'},

--- a/src/app/pages/medical-sources-editor/medical-sources-editor.component.ts
+++ b/src/app/pages/medical-sources-editor/medical-sources-editor.component.ts
@@ -33,6 +33,7 @@ export class MedicalSourcesEditorComponent implements OnInit {
     {key: 'Athena', value: 'athena'},
     {key: 'Cerner', value: 'cerner'},
     {key: 'CHBase', value: 'chbase'},
+    // {key: 'Charm', value: 'charm'},
     {key: 'Darena', value: 'darena'},
     {key: 'DrChrono', value: 'drchrono'},
     {key: 'eCW/Healow', value: 'eclinicalworks'},
@@ -53,6 +54,7 @@ export class MedicalSourcesEditorComponent implements OnInit {
     {key: 'Nextgen Office', value: 'nextgenoffice'},
     // nhs.yaml
     {key: 'OneMedical', value: 'onemedical'},
+    // {key: 'PracticeFusion', value: 'pointclickcare'},
     {key: 'PracticeFusion', value: 'practicefusion'},
     {key: 'Qualifacts Carelogic', value: 'qualifacts-carelogic'},
     {key: 'Qualifacts Credible', value: 'qualifacts-credible'},


### PR DESCRIPTION
## Purpose
Allow toolbox users to filter medical sources by the Medent platform.

## Change Summary
- Add a `Medent` option to `MedicalSourcesEditorComponent.platformTypes`.
- Map the option to the `medent` platform value used in Lighthouse source-search filters.

## Related Tickets or Requests
None.

## Systems Impacted
- **Direct:** Medical Sources Editor platform filter.
- **Potential:** Lighthouse medical-source search requests when Medent is selected.

## Potential Impact
Low. This adds one filter option and does not change existing options or default search behavior. An incorrect platform value would only cause the Medent-filtered search to return no matching results.

## Alternatives Considered
No separate UI or special-case filtering was added because Medent follows the existing platform-option pattern.

## Testing Plan
Not run; this is a data-only UI option change. Verify that Medent appears in the platform selector and selecting it refreshes results using `medent` as the platform filter.

## Back Out Plan
Revert commit `000fdbb` or remove the Medent entry from `platformTypes`.

## Security Review
No authentication, authorization, sensitive-data handling, dependencies, or infrastructure are changed.

## Security Risk Assessment
- **Risk Rating:** Low
- **Notes:** The change only exposes an existing platform value in a client-side filter list.

## Review Acknowledgement
- [ ] Business Approver has reviewed
- [ ] Security Approver has reviewed